### PR TITLE
Add Dockerfile to build and run Next.js application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use node:16-alpine as the base image
+FROM node:16-alpine
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the Next.js application
+RUN npm run build
+
+# Expose port 3000
+EXPOSE 3000
+
+# Start the Next.js server
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ npm start
 
 Access the application at `http://localhost:3000`.
 
+## Docker
+
+To build and run the Docker container:
+
+1. Build the Docker image:
+
+```bash
+docker build -t dialogflow-saas .
+```
+
+2. Run the Docker container:
+
+```bash
+docker run -p 3000:3000 dialogflow-saas
+```
+
+Access the application at `http://localhost:3000`.
+
 ## Screenshots
 
 ![Dashboard](./images/dashboard.png)

--- a/dialogflow-developer-buddy/Dockerfile
+++ b/dialogflow-developer-buddy/Dockerfile
@@ -1,0 +1,23 @@
+# Use node:16-alpine as the base image
+FROM node:16-alpine
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the Next.js application
+RUN npm run build
+
+# Expose port 3000
+EXPOSE 3000
+
+# Start the Next.js server
+CMD ["npm", "start"]

--- a/dialogflow-developer-buddy/README.md
+++ b/dialogflow-developer-buddy/README.md
@@ -34,3 +34,21 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Docker
+
+To build and run the Docker container:
+
+1. Build the Docker image:
+
+```bash
+docker build -t dialogflow-developer-buddy .
+```
+
+2. Run the Docker container:
+
+```bash
+docker run -p 3000:3000 dialogflow-developer-buddy
+```
+
+Access the application at `http://localhost:3000`.


### PR DESCRIPTION
Add Dockerfile to the repository to enable Docker support for the Next.js application.

* **Dockerfile**:
  - Use `node:16-alpine` as the base image.
  - Set the working directory to `/app`.
  - Copy `package.json` and `package-lock.json` to the working directory.
  - Install dependencies using `npm install`.
  - Copy the rest of the application code to the working directory.
  - Build the Next.js application using `npm run build`.
  - Expose port 3000 and start the Next.js server using `npm start`.

* **README.md**:
  - Add instructions on how to build and run the Docker container.
  - Include Docker commands to build and run the container.